### PR TITLE
Update custom.css

### DIFF
--- a/Custom Loader/css/custom.css
+++ b/Custom Loader/css/custom.css
@@ -1,5 +1,5 @@
 .loadingthrobber_Container_3sa1N.loadingthrobber_PreloadThrobber_1-epa {
-    background: var(--loader-color);
+    background: var(--loader-color) !important;
 }
 .loadingthrobber_Container_3sa1N img {
 	content: var(--loader-image);


### PR DESCRIPTION
Prevent system-wide themes (Obsidian) from overwriting loading screen background. This is to ensure that background colour can be matched to image background if desired.